### PR TITLE
feat: add feature to toggle overlaying image

### DIFF
--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -4,24 +4,26 @@ import { Icons, IconButton } from "@storybook/components";
 import { TOOL_ID } from "./constants";
 
 export const Tool = () => {
-  const [{ myAddon }, updateGlobals] = useGlobals();
+  const [{ pixelPerfect }, updateGlobals] = useGlobals();
 
-  const toggleMyTool = useCallback(
+  const toggleOverlay = useCallback(
     () =>
       updateGlobals({
-        myAddon: myAddon ? undefined : true,
+        pixelPerfect: {
+          active: !pixelPerfect?.active
+        }
       }),
-    [myAddon]
+    [pixelPerfect?.active]
   );
 
   return (
     <IconButton
       key={TOOL_ID}
-      active={myAddon}
-      title="Enable my addon"
-      onClick={toggleMyTool}
+      active={pixelPerfect?.active}
+      title="Toggle the component overlaying image"
+      onClick={toggleOverlay}
     >
-      <Icons icon="lightning" />
+      <Icons icon={pixelPerfect?.active ? 'eye' : 'eyeclose' } />
     </IconButton>
   );
 };

--- a/src/preset/manager.ts
+++ b/src/preset/manager.ts
@@ -11,7 +11,7 @@ addons.register(ADDON_ID, () => {
   addons.add(TOOL_ID, {
     type: types.TOOL,
     title: "My addon",
-    match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
+    match: ({ viewMode }) => !!(viewMode && viewMode.match(/^story$/)),
     render: Tool,
   });
 

--- a/src/withGlobals.ts
+++ b/src/withGlobals.ts
@@ -3,7 +3,7 @@ import { useEffect, useGlobals } from "@storybook/addons";
 import renderOverlay from './utils/render-overlay';
 
 export const withGlobals: DecoratorFunction = (StoryFn, context) => {
-  const [{ myAddon }] = useGlobals();
+  const [{ myAddon, pixelPerfect }] = useGlobals();
   // Is the addon being used in the docs panel
   const isInDocs = context.viewMode === "docs";
   const { theme } = context.globals;
@@ -23,16 +23,19 @@ export const withGlobals: DecoratorFunction = (StoryFn, context) => {
   }, [myAddon, theme]);
 
   useEffect(() => {
-    if (context.parameters?.pixelPerfect?.overlaySrc) {
+    if (
+      context.parameters?.pixelPerfect?.overlaySrc
+      && pixelPerfect?.active
+    ) {
       const overlay = renderOverlay({
         src: context.parameters.pixelPerfect.overlaySrc
       });
 
-      () => {
+      return () => {
         overlay.remove();
       }
     }
-  }, [context.parameters?.pixelPerfect?.overlaySrc]);
+  }, [context.parameters?.pixelPerfect?.overlaySrc, pixelPerfect?.active]);
 
   return StoryFn();
 };


### PR DESCRIPTION
This commit will add a function to toggle the visibility of the overlay so that you can evaluate
the appearance of the component without the overlay.

You can show and hide the overlay using the icon button with an eye on the toolbar.