### PR TITLE
docs: remove demo `myAddonParameter` parameter from button stories

### DIFF
--- a/stories/Button.stories.js
+++ b/stories/Button.stories.js
@@ -4,13 +4,6 @@ import { Button } from "./Button";
 export default {
   title: "Example/Button",
   component: Button,
-  parameters: {
-    myAddonParameter: `
-<MyComponent boolProp scalarProp={1} complexProp={{ foo: 1, bar: '2' }}>
-  <SomeOtherComponent funcProp={(a) => a.id} />
-</MyComponent>
-`,
-  },
 };
 
 const Template = (args) => <Button {...args} />;


### PR DESCRIPTION
This commit will remove the use of the demo parameter from the stories of the Button component that
has been in the repository since it was initialized. The functionality of this parameter has
already been removed, but an example of its use remains. This commit will remove exactly the use case
for this parameter.