### PR TITLE
fix: fix overlay cleanup

### DIFF
--- a/src/utils/overlay.ts
+++ b/src/utils/overlay.ts
@@ -5,7 +5,7 @@ interface RenderOverlayArgs {
   src: string;
 }
 
-const renderOverlay = ({ src }: RenderOverlayArgs) => {
+export const renderOverlay = ({ src }: RenderOverlayArgs) => {
   const root = document.querySelector(rootSelector);
   if (!root) return;
 
@@ -26,8 +26,10 @@ const renderOverlay = ({ src }: RenderOverlayArgs) => {
   overlay.style.pointerEvents = "none";
 
   root.appendChild(overlay);
-
-  return overlay;
 }
 
-export default renderOverlay;
+export const removeOverlay =() => {
+  const overlay = document.querySelector(`${rootSelector} #${overlayId}`);
+  if (!overlay) return;
+  overlay.remove();
+}

--- a/src/withGlobals.ts
+++ b/src/withGlobals.ts
@@ -1,6 +1,6 @@
 import type { DecoratorFunction } from "@storybook/addons";
 import { useEffect, useGlobals } from "@storybook/addons";
-import renderOverlay from './utils/render-overlay';
+import { renderOverlay, removeOverlay } from './utils/overlay';
 
 export const withGlobals: DecoratorFunction = (StoryFn, context) => {
   const [{ pixelPerfect }] = useGlobals();
@@ -10,13 +10,11 @@ export const withGlobals: DecoratorFunction = (StoryFn, context) => {
       context.parameters?.pixelPerfect?.overlaySrc
       && pixelPerfect?.active
     ) {
-      const overlay = renderOverlay({
+      renderOverlay({
         src: context.parameters.pixelPerfect.overlaySrc
       });
 
-      return () => {
-        overlay.remove();
-      }
+      return () => removeOverlay();
     }
   }, [context.parameters?.pixelPerfect?.overlaySrc, pixelPerfect?.active]);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "noImplicitAny": true,
     "rootDir": "./src",
     "skipLibCheck": true,
-    "target": "es5"
+    "target": "es5",
+    "strictNullChecks": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
This commit will fix a bug when trying to remove the overlay in `useEffect()` during cleanup when
the overlay is not defined.

This error might not have occurred if the `strictNullChecks` option in _tsconfig.json_ had been set
to `true`, so this commit will also set that option to `true`.