### PR TITLE
feat: add feature to toggle color inversion of the overlay

### DIFF
--- a/src/components/panel-content/panel-content.tsx
+++ b/src/components/panel-content/panel-content.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo, useEffect, useCallback } from "react";
-import ControlTable from './ui/control-table/control-table';
-import Slider from '@mui/material/Slider';
+import { Checkbox, Slider } from "@mui/material";
 import { useAddonState, useStorybookState, useParameter, useChannel } from "@storybook/api";
-import { DEFAULT_OVERLAY_OPTIONS, EVENTS, DYNAMIC_OVERLAYS_OPTIONS_STATE, PARAM_KEY } from "../../constants";
-import { Parameter, DynamicOverlayOptions } from "../../types";
 import { themes } from "@storybook/theming";
+import ControlTable from './ui/control-table/control-table';
+import { DEFAULT_DYNAMIC_OVERLAY_OPTIONS, EVENTS, DYNAMIC_OVERLAYS_OPTIONS_STATE, PARAM_KEY } from "../../constants";
+import { Parameter, DynamicOverlayOptions } from "../../types";
 
 const PanelContent = () => {
   const parameter = useParameter<Parameter>(PARAM_KEY);
@@ -48,7 +48,7 @@ const PanelContent = () => {
               value={
                 currentDynamicOverlayOptions?.opacity
                 ?? parameter?.overlay?.opacity
-                ?? DEFAULT_OVERLAY_OPTIONS.opacity
+                ?? DEFAULT_DYNAMIC_OVERLAY_OPTIONS.opacity
               }
               min={0}
               max={1}
@@ -56,6 +56,21 @@ const PanelContent = () => {
               onChange={(_, value) => updateOverlayOptions({ opacity: value as number })}
               aria-label="Opacity"
               valueLabelDisplay="auto"
+              sx={{
+                color: themes.normal.colorSecondary,
+              }}
+            />,
+          },
+          {
+            name: "Enable color inversion",
+            control: <Checkbox
+              checked={
+                currentDynamicOverlayOptions.colorInversion
+                ?? parameter?.overlay?.colorInversion
+                ?? DEFAULT_DYNAMIC_OVERLAY_OPTIONS.colorInversion
+              }
+              onChange={(_, value) => updateOverlayOptions({ colorInversion: value })}
+              aria-label="Toggle color inversion"
               sx={{
                 color: themes.normal.colorSecondary,
               }}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import { DynamicOverlayOptions } from "./types";
+
 export const ADDON_ID = "pixel-perfect-storybook-addon";
 export const TOGGLE_OVERLAY_TOOL_ID = `${ADDON_ID}/toggle-overlay-tool`;
 export const PANEL_ID = `${ADDON_ID}/panel`;
@@ -5,8 +7,9 @@ export const PARAM_KEY = `pixelPerfect`;
 
 export const DYNAMIC_OVERLAYS_OPTIONS_STATE = `${ADDON_ID}/dynamic-overlays-options-state`;
 
-export const DEFAULT_OVERLAY_OPTIONS = {
+export const DEFAULT_DYNAMIC_OVERLAY_OPTIONS: DynamicOverlayOptions = {
   opacity: 0.5,
+  colorInversion: true,
 };
 
 export const EVENTS = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type OverlayOptions = {
   src: string;
   opacity?: number;
+  colorInversion?: boolean;
 };
 
 export type Parameter = {

--- a/src/utils/overlay.ts
+++ b/src/utils/overlay.ts
@@ -1,10 +1,13 @@
-import { DEFAULT_OVERLAY_OPTIONS } from "../constants";
 import { OverlayOptions } from "../types";
 
 const rootSelector = "#root";
 const overlayId = "pixel-perfect-overlay";
 
-export const renderOverlay = ({ src, opacity }: OverlayOptions) => {
+export const renderOverlay = ({
+  src,
+  opacity,
+  colorInversion,
+}: Required<OverlayOptions>) => {
   const root = document.querySelector(rootSelector);
   if (!root) return;
 
@@ -16,20 +19,17 @@ export const renderOverlay = ({ src, opacity }: OverlayOptions) => {
     const newOverlay = document.createElement("img");
     
     newOverlay.setAttribute("id", overlayId);
-    newOverlay.setAttribute("src", src);
     newOverlay.setAttribute("alt", "pixel perfect overlaying image");
-
     newOverlay.style.position = "absolute";
     newOverlay.style.top = `${rootRect.top}px`;
     newOverlay.style.left = `${rootRect.left}px`;
     newOverlay.style.zIndex = "100000";
-
-    newOverlay.style.opacity = opacity !== undefined
-      ? `${opacity}`
-      : `${DEFAULT_OVERLAY_OPTIONS.opacity}`;
-
-      newOverlay.style.filter = "invert(1)";
-      newOverlay.style.pointerEvents = "none";
+    newOverlay.style.pointerEvents = "none";
+    
+    // Customizations
+    newOverlay.setAttribute("src", src);
+    newOverlay.style.opacity = `${opacity}`;
+    newOverlay.style.filter = colorInversion ? "invert(1)" : "none";
 
     root.appendChild(newOverlay);
   } else {
@@ -39,6 +39,11 @@ export const renderOverlay = ({ src, opacity }: OverlayOptions) => {
 
     if (Number(existingOverlay.style.opacity) !== opacity) {
       existingOverlay.style.opacity = `${opacity}`;
+    }
+
+    const isInverted = existingOverlay.style.filter === "invert(1)";
+    if (isInverted !== colorInversion) {
+      existingOverlay.style.filter = colorInversion ? "invert(1)" : "none";
     }
   }
 }

--- a/src/withOverlay.ts
+++ b/src/withOverlay.ts
@@ -1,5 +1,5 @@
 import { DecoratorFunction, useChannel, useEffect, useState } from "@storybook/addons";
-import { EVENTS } from "./constants";
+import { DEFAULT_DYNAMIC_OVERLAY_OPTIONS, EVENTS } from "./constants";
 import { DynamicOverlayOptions } from "./types";
 import { renderOverlay, removeOverlay } from './utils/overlay';
 
@@ -20,6 +20,7 @@ export const withOverlay: DecoratorFunction = (StoryFn, context) => {
   useEffect(() => {
     if (global?.active && parameter) {
       renderOverlay({
+        ...DEFAULT_DYNAMIC_OVERLAY_OPTIONS,
         ...parameter.overlay,
         ...currentDynamicOverlayOptions,
       });

--- a/stories/Header.stories.js
+++ b/stories/Header.stories.js
@@ -21,12 +21,17 @@ LoggedIn.parameters = {
   },
 };
 
-export const LoggedOut = Template.bind({});
+export const LoggedOut = (args) => (
+  <div style={{ paddingLeft: 20 }}>
+    <Header {...args} />
+  </div>
+);
 LoggedOut.args = {};
 LoggedOut.parameters = {
   pixelPerfect: {
     overlay: {
       src: "/pixel-perfect/header-logged-out.png",
+      colorInversion: false,
     },
   },
 };


### PR DESCRIPTION
This commit will add a feature to toggle color inversion of the overlay so that you can better
customize the overlay for different situations.

The color inversion of the overlay can be set via the story parameter:
`pixelPerfect.overlay.colorInversion`. Also, it can be set via the corresponding control on the
addon panel in Storybook.

If you set color inversion via the panel, then the changes will be reset after the page is
reloaded.

The settings set via the control override the settings set via the parameter. If you do not set
color inversion in the parameters or via the control, then the default color inversion settings
will be used.