### PR TITLE
feat: add feature to reset overlay options

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
   "dependencies": {
     "@emotion/react": "11.10.5",
     "@emotion/styled": "11.10.5",
+    "@mui/icons-material": "5.11.0",
     "@mui/material": "5.11.0"
   }
 }

--- a/src/components/panel-content/ui/control-table/control-table.tsx
+++ b/src/components/panel-content/ui/control-table/control-table.tsx
@@ -3,15 +3,17 @@ import { styled, themes } from "@storybook/theming";
 
 // Interfaces
 interface Cell {
-  side: "left" | "right";
+  side: "left" | "center" | "right";
 }
 
 interface ControlTableRow {
   name: string;
   control: ReactNode;
+  reset: ReactNode;
 }
 
 interface ControlTable {
+  headReset: ReactNode;
   rows: ControlTableRow[];
 }
 
@@ -28,7 +30,7 @@ const Row = styled.tr({
 
 const commonCellStyles = ({ side }: Cell) => ({
   width: side === "left" ? "25%" : "75%",
-  padding: side === "left" ? "10px 15px 10px 30px" : "10px 30px 10px 15px",
+  padding: side === "left" ? "10px 15px 10px 30px" : side === "center" ? "10px 15px" : "10px 30px 10px 15px",
 });
 
 const HeadCell = styled.th<Cell>(({ side }) => ({
@@ -50,7 +52,8 @@ const ControlTable = (props: ControlTable) => {
       <thead>
         <Row>
           <HeadCell side="left">Name</HeadCell>
-          <HeadCell side="right">Control</HeadCell>
+          <HeadCell side="center">Control</HeadCell>
+          <HeadCell side="right">{props.headReset}</HeadCell>
         </Row>
       </thead>
 
@@ -58,7 +61,8 @@ const ControlTable = (props: ControlTable) => {
         {props.rows.map(row => (
           <Row key={row.name}>
             <BodyCell side="left">{row.name}</BodyCell>
-            <BodyCell side="right">{row.control}</BodyCell>
+            <BodyCell side="center">{row.control}</BodyCell>
+            <BodyCell side="right">{row.reset}</BodyCell>
           </Row>
         ))}
       </tbody>

--- a/src/components/panel-content/ui/reset-button/reset-button.tsx
+++ b/src/components/panel-content/ui/reset-button/reset-button.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { IconButton, Tooltip } from "@mui/material";
+import { SettingsBackupRestore } from '@mui/icons-material';
+import { themes } from "@storybook/theming";
+
+interface ResetButtonProps {
+  title: string;
+  canReset: boolean;
+  onClick: () => void;
+}
+
+export const ResetButton = (props: ResetButtonProps) => {
+  return (
+    <Tooltip title={props.title}>
+      <IconButton onClick={props.onClick}>
+        <SettingsBackupRestore
+          sx={{
+            color: props.canReset ? themes.normal.colorSecondary : themes.normal.base,
+          }}
+        />
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2137,6 +2137,13 @@
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.11.0.tgz#7ae98a3df113270097f3024c713c4efce5537c6a"
   integrity sha512-Bmogung451ezVv2YI1RvweOIVsTj2RQ4Fk61+e/+8LFPLTFEwVGbL0YhNy1VB5tri8pzGNV228kxtWVTFooQkg==
 
+"@mui/icons-material@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.11.0.tgz#9ea6949278b2266d2683866069cd43009eaf6464"
+  integrity sha512-I2LaOKqO8a0xcLGtIozC9xoXjZAto5G5gh0FYUMAlbsIHNHIjn4Xrw9rvjY20vZonyiGrZNMAlAXYkY6JvhF6A==
+  dependencies:
+    "@babel/runtime" "^7.20.6"
+
 "@mui/material@5.11.0":
   version "5.11.0"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.11.0.tgz#01ead6ca389de440fbc78b2dbb8547845ca40f93"


### PR DESCRIPTION
This commit will add the ability to reset overlay options set via the addon panel to revert the
overlay to its previous state after experimenting with its options. To do this, reset buttons will
be added to the addon panel.

There are reset buttons for each option, as well as one reset button for all options at once.

When the current values of the options differ from the initial values, then the buttons
corresponding to the reset buttons are highlighted. This is necessary to understand which options
have been changed as a result of customization.

The `@mui/icons-material` package has been installed for reset icon.